### PR TITLE
feat: SQLite database backup strategy (#20)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,7 @@ services:
 
   db-backup:
     image: alpine:3.19
+    restart: unless-stopped
     depends_on:
       - orchestrator
     environment:
@@ -53,8 +54,9 @@ services:
     command:
       - |
         apk add --no-cache sqlite
+        sleep 60
         while true; do
-          sh /backup-db.sh /data/trade.db /data/backups
+          sh /backup-db.sh /data/trade.db /data/backups || echo "[WARNING] Backup failed, will retry in 6h"
           sleep 21600
         done
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,5 +40,23 @@ services:
     depends_on:
       - orchestrator
 
+  db-backup:
+    image: alpine:3.19
+    depends_on:
+      - orchestrator
+    environment:
+      - DB_BACKUP_RETENTION_DAYS=30
+    volumes:
+      - ./data:/data
+      - ./scripts/backup-db.sh:/backup-db.sh:ro
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        apk add --no-cache sqlite
+        while true; do
+          sh /backup-db.sh /data/trade.db /data/backups
+          sleep 21600
+        done
+
 volumes:
   redis-data:

--- a/scripts/backup-db.sh
+++ b/scripts/backup-db.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# SQLite Database Backup Script
+# Usage: ./scripts/backup-db.sh [DB_PATH] [BACKUP_DIR]
+#
+# Can be run standalone or via cron:
+#   0 */6 * * * /app/scripts/backup-db.sh /app/data/trade.db /app/data/backups
+
+set -euo pipefail
+
+DB_PATH="${1:-./data/trade.db}"
+BACKUP_DIR="${2:-./data/backups}"
+RETENTION_DAYS="${DB_BACKUP_RETENTION_DAYS:-30}"
+
+mkdir -p "$BACKUP_DIR"
+
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+BACKUP_FILE="${BACKUP_DIR}/trade_${TIMESTAMP}.db"
+
+if [ ! -f "$DB_PATH" ]; then
+  echo "ERROR: Database not found at $DB_PATH" >&2
+  exit 1
+fi
+
+# Use SQLite .backup for consistent snapshot
+sqlite3 "$DB_PATH" ".backup '${BACKUP_FILE}'"
+
+if [ $? -eq 0 ]; then
+  SIZE=$(du -h "$BACKUP_FILE" | cut -f1)
+  echo "[$(date -Iseconds)] Backup created: $BACKUP_FILE ($SIZE)"
+
+  # Compress backup
+  gzip "$BACKUP_FILE"
+  echo "[$(date -Iseconds)] Compressed: ${BACKUP_FILE}.gz"
+
+  # Remove backups older than RETENTION_DAYS
+  find "$BACKUP_DIR" -name "trade_*.db.gz" -mtime +$RETENTION_DAYS -delete
+  echo "[$(date -Iseconds)] Cleaned backups older than $RETENTION_DAYS days"
+else
+  echo "ERROR: Backup failed" >&2
+  exit 1
+fi

--- a/scripts/backup-db.sh
+++ b/scripts/backup-db.sh
@@ -5,7 +5,7 @@
 # Can be run standalone or via cron:
 #   0 */6 * * * /app/scripts/backup-db.sh /app/data/trade.db /app/data/backups
 
-set -euo pipefail
+set -uo pipefail
 
 DB_PATH="${1:-./data/trade.db}"
 BACKUP_DIR="${2:-./data/backups}"
@@ -21,10 +21,14 @@ if [ ! -f "$DB_PATH" ]; then
   exit 1
 fi
 
-# Use SQLite .backup for consistent snapshot
-sqlite3 "$DB_PATH" ".backup '${BACKUP_FILE}'"
+# Clean any leftover uncompressed backups from previous failed runs
+find "$BACKUP_DIR" -name "trade_*.db" -not -name "trade_*.db.gz" -delete 2>/dev/null || true
 
-if [ $? -eq 0 ]; then
+# Checkpoint WAL before backup for operational cleanliness
+sqlite3 "$DB_PATH" "PRAGMA wal_checkpoint(TRUNCATE);" 2>/dev/null || true
+
+# Use SQLite .backup for consistent snapshot
+if sqlite3 "$DB_PATH" ".backup '${BACKUP_FILE}'"; then
   SIZE=$(du -h "$BACKUP_FILE" | cut -f1)
   echo "[$(date -Iseconds)] Backup created: $BACKUP_FILE ($SIZE)"
 
@@ -33,9 +37,10 @@ if [ $? -eq 0 ]; then
   echo "[$(date -Iseconds)] Compressed: ${BACKUP_FILE}.gz"
 
   # Remove backups older than RETENTION_DAYS
-  find "$BACKUP_DIR" -name "trade_*.db.gz" -mtime +$RETENTION_DAYS -delete
+  find "$BACKUP_DIR" -name "trade_*.db.gz" -mtime +"$RETENTION_DAYS" -delete
   echo "[$(date -Iseconds)] Cleaned backups older than $RETENTION_DAYS days"
 else
-  echo "ERROR: Backup failed" >&2
+  echo "ERROR: Backup failed for $DB_PATH" >&2
+  rm -f "$BACKUP_FILE" 2>/dev/null || true
   exit 1
 fi


### PR DESCRIPTION
## Summary
- `scripts/backup-db.sh` — SQLite `.backup` で整合性あるスナップショット
- gzip圧縮 + 保持期間（デフォルト30日）で自動クリーンアップ
- `docker-compose.yml` に `db-backup` サービス追加（6時間毎）
- `DB_BACKUP_RETENTION_DAYS` で保持期間設定可能

## Test plan
- [x] バックアップスクリプトの構文確認
- [ ] `docker compose up` でバックアップサービス正常起動確認
- [ ] `./scripts/backup-db.sh` 手動実行でバックアップ作成確認

Closes #20